### PR TITLE
docs: fix stale repo structure in copilot-instructions (follow-up to #17)

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -41,12 +41,10 @@ action-style-guide/
 │   ├── reviewer.py              # LLM interaction with extended thinking (shared)
 │   ├── github_handler.py        # GitHub API interactions (action only)
 │   ├── fix_applier.py           # Apply fixes to markdown files (shared)
-│   ├── prompt_loader.py         # Load prompts and rules (shared)
-│   ├── prompts/                 # Minimal rule-agnostic prompt (identical for all categories)
-│   │   ├── writing-prompt.md
-│   │   ├── math-prompt.md
-│   │   ├── ...
-│   │   └── v0.6.1/             # Archived previous prompts
+│   ├── categories.py            # Single source of truth for category names (VALID_CATEGORIES)
+│   ├── prompts/                 # Single rule-agnostic prompt, shared across all categories
+│   │   ├── prompt.md            # The shared prompt
+│   │   └── v0.6.1/              # Archived previous (per-category) prompts
 │   └── rules/                   # Category-specific rules
 │       ├── writing-rules.md
 │       ├── math-rules.md

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -79,9 +79,9 @@ action-style-guide/
 - **Single source of truth**: Version in `__init__.py`
 
 ### Prompt Files
-- **Location**: `style_checker/prompts/*.md`
-- **Design**: All 8 prompt files are identical (rule-agnostic). Consolidation to single `prompt.md` planned (see PLAN.md 4.6).
-- **Version tracking**: Each prompt has version comment at top: `<!-- Prompt Version: X.Y.Z | Last Updated: YYYY-MM-DD | Description -->`
+- **Location**: `style_checker/prompts/prompt.md`
+- **Design**: A single rule-agnostic prompt shared across all 8 categories (consolidated in #17; previously one identical file per category).
+- **Version tracking**: The prompt has a version comment at top: `<!-- Prompt Version: X.Y.Z | Last Updated: YYYY-MM-DD | Description -->`
 - **Archive**: Previous prompts archived in `style_checker/prompts/v0.6.1/`
 
 ### GitHub Integration


### PR DESCRIPTION
## Summary

Small documentation follow-up to #17. Brings `.github/copilot-instructions.md` in line with the consolidated layout #17 introduced. Two stale spots, both describing the pre-#17 structure:

**1. Repository Structure diagram**
- listed `prompt_loader.py` — **deleted** in #17 (was dead production code)
- listed the per-category `{name}-prompt.md` files (`writing-prompt.md`, `math-prompt.md`, …) — **deleted** in #17, consolidated into a single shared prompt

**2. "Prompt Files" section**
- described "All 8 prompt files are identical" and listed the consolidation as *"planned (see PLAN.md 4.6)"* — #17 **completed** it

## What changed

- Diagram now shows `categories.py` (single source of truth for `VALID_CATEGORIES`) and the single `prompts/prompt.md`; `prompts/v0.6.1/` clarified as the archived previous (per-category) prompts.
- "Prompt Files" prose updated: location → `prompts/prompt.md`; design reworded to "a single rule-agnostic prompt shared across all 8 categories (consolidated in #17)".

Docs-only; no code or test changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)