### PR TITLE
fix: bump GitHub Actions to Node 24-compatible versions (#16)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,10 +19,10 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v3
+      uses: astral-sh/setup-uv@v7
       with:
         enable-cache: true
 
@@ -40,10 +40,10 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v3
+      uses: astral-sh/setup-uv@v7
       with:
         enable-cache: true
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -21,12 +21,12 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '22'
 
       - name: Build with MyST
         run: npx -y mystmd build --html
@@ -35,7 +35,7 @@ jobs:
           BASE_URL: /action-style-guide
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: docs/_build/html
 
@@ -48,4 +48,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Bumped GitHub Actions to Node 24-compatible versions** — GitHub forces Node 24 as the default runner runtime from 2026-06-02 (Node 20 fully removed 2026-09-16). Updated `actions/checkout@v4→v5` and `astral-sh/setup-uv@v3→v7` in `action.yml` and CI; the docs workflow now uses `actions/setup-node@v4→v6` (Node 22), `actions/upload-pages-artifact@v3→v5`, and `actions/deploy-pages@v4→v5`. Resolves #16.
+
 ## [0.7.2] - 2026-02-16
 
 ### Fixed

--- a/action.yml
+++ b/action.yml
@@ -66,13 +66,13 @@ runs:
   using: 'composite'
   steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       with:
         token: ${{ inputs.github-token }}
         fetch-depth: 0
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v3
+      uses: astral-sh/setup-uv@v7
       with:
         enable-cache: true
         # By default setup-uv searches **/uv.lock in the consumer repo, which


### PR DESCRIPTION
## Summary

Resolves #16. GitHub forced **Node 24 as the default runner runtime on 2026-06-02** (three days before this PR); **Node 20 is fully removed on 2026-09-16**. The action and its workflows still pinned Node-20 JS actions (`actions/checkout@v4`, `astral-sh/setup-uv@v3`, …), which now emit deprecation warnings and are on borrowed time.

## What changed

Each action is bumped to its **latest floating major tag that runs on Node 24**, verified against the action's own `runs.using` field:

| Action | Before | After | Runtime |
|--------|--------|-------|---------|
| `actions/checkout` | `@v4` | `@v5` | node24 |
| `astral-sh/setup-uv` | `@v3` | `@v7` | node24 |
| `actions/setup-node` (docs) | `@v4` | `@v6` | node24 |
| `actions/upload-pages-artifact` (docs) | `@v3` | `@v5` | composite |
| `actions/deploy-pages` (docs) | `@v4` | `@v5` | node24 |

Files touched: `action.yml`, `.github/workflows/ci.yml`, `.github/workflows/docs.yml`.

**Notes:**
- `astral-sh/setup-uv` publishes **no floating `v8` major tag** (only `v8.0.0/.1/.2`); `v7` is the latest floating major and already runs on Node 24, so it's the right pin to stay on the floating-major convention.
- `checkout` pinned to `@v5` (first/stable Node 24 major) rather than the brand-new `@v6` — minimal, well-tested bump that fully satisfies the Node 24 requirement.
- Also bumped the docs build's `node-version: '20' → '22'` (Node 20 LTS reached EOL ~April 2026); 22 is the current LTS.

## Test plan

- [x] All three YAML files parse
- [x] Each new tag's `runs.using` confirmed `node24` (or `composite`) before pinning
- [ ] CI green on this PR (validates `checkout@v5` + `setup-uv@v7` end-to-end)
- [ ] Docs workflow exercised on next `docs/**` change (or via `workflow_dispatch`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)